### PR TITLE
Pass both base and ref ID to the exe

### DIFF
--- a/Scripts/Source/User/MantellaConstants.psc
+++ b/Scripts/Source/User/MantellaConstants.psc
@@ -32,7 +32,8 @@ string property KEY_REPLYTYPE_ENDCONVERSATION = "mantella_end_conversation" auto
 
 ;Actors
 string property KEY_ACTORS = "mantella_actors" auto
-string property KEY_ACTOR_ID = "mantella_actor_id" auto
+string property KEY_ACTOR_BASEID = "mantella_actor_baseid" auto
+string property KEY_ACTOR_REFID = "mantella_actor_refid" auto
 string property KEY_ACTOR_NAME = "mantella_actor_name" auto
 string property KEY_ACTOR_GENDER = "mantella_actor_gender" auto
 string property KEY_ACTOR_RACE = "mantella_actor_race" auto

--- a/Scripts/Source/User/MantellaConversation.psc
+++ b/Scripts/Source/User/MantellaConversation.psc
@@ -600,7 +600,8 @@ endFunction
 
 int function buildActorSetting(Actor actorToBuild)    
     int handle = F4SE_HTTP.createDictionary()
-    F4SE_HTTP.setInt(handle, mConsts.KEY_ACTOR_ID, (actorToBuild.getactorbase() as form).getformid())
+    F4SE_HTTP.setInt(handle, mConsts.KEY_ACTOR_BASEID, (actorToBuild.getactorbase() as form).getformid())
+    F4SE_HTTP.setInt(handle, mConsts.KEY_ACTOR_REFID, (actorToBuild as form).getformid())
     F4SE_HTTP.setString(handle, mConsts.KEY_ACTOR_NAME, actorToBuild.GetDisplayName())
     F4SE_HTTP.setBool(handle, mConsts.KEY_ACTOR_ISPLAYER, actorToBuild == game.getplayer())
     F4SE_HTTP.setInt(handle, mConsts.KEY_ACTOR_GENDER, actorToBuild.getleveledactorbase().getsex())


### PR DESCRIPTION
- Base IDs of NPCs are needed to look up the NPC in fallout4_characters.csv. 
- Ref IDs are needed to be able to store memories of generic NPCs without name conflicts.