### PR TITLE
Improved conversation start response times

### DIFF
--- a/Scripts/Source/User/MantellaConstants.psc
+++ b/Scripts/Source/User/MantellaConstants.psc
@@ -15,10 +15,12 @@ string property EVENT_ACTIONS = "MantellaConversation_Action_" auto
 string property PREFIX = "mantella_" auto
 string property KEY_REQUESTTYPE = "mantella_request_type" auto
 string property KEY_REPLYTYPE = "mantella_reply_type" auto
+string property KEY_INPUTTYPE = "mantella_input_type" auto
 
 string property KEY_REQUEST_EXTRA_ACTIONS = "mantella_extra_actions" auto
 
 ;Conversation
+string property KEY_REQUESTTYPE_INIT = "mantella_initialize" auto
 string property KEY_REQUESTTYPE_STARTCONVERSATION = "mantella_start_conversation" auto
 string property KEY_REQUESTTYPE_CONTINUECONVERSATION = "mantella_continue_conversation" auto
 string property KEY_REQUESTTYPE_PLAYERINPUT = "mantella_player_input" auto
@@ -26,6 +28,7 @@ string property KEY_REQUESTTYPE_ENDCONVERSATION = "mantella_end_conversation" au
 
 string property KEY_REPLYTTYPE_STARTCONVERSATIONCOMPLETED = "mantella_start_conversation_completed" auto
 
+string property KEY_REPLYTTYPE_INITCOMPLETED = "mantella_init_completed" auto
 string property KEY_REPLYTYPE_NPCTALK = "mantella_npc_talk" auto
 string property KEY_REPLYTYPE_PLAYERTALK = "mantella_player_talk" auto
 string property KEY_REPLYTYPE_ENDCONVERSATION = "mantella_end_conversation" auto
@@ -62,6 +65,9 @@ string property KEY_CONTEXT_CUSTOMVALUES = "mantella_custom_context_values" auto
 string property KEY_REQUESTTYPE_TTS = "mantella_tts" auto
 string property KEY_INPUT_NAMESINCONVERSATION = "mantella_names_in_conversation" auto
 string property KEY_TRANSCRIBE = "mantella_transcribe" auto
+string property KEY_INPUTTYPE_TEXT = "mantella_text_input" auto
+string property KEY_INPUTTYPE_MIC = "mantella_mic_input" auto
+string property KEY_INPUTTYPE_PTT = "mantella_push_to_talk" auto
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;       Possible actions      ;


### PR DESCRIPTION
- Added `mantella_initialize` request as soon as a conversation starts (and before context and NPC data are loaded):
    - This is an empty request which forces the Mantella server to load configured settings such as the characters CSV, the TTS service, the chosen LLM etc
    - Sending this request allows the server to get ready while the Papyrus script loads context and NPC data, saving time
    - The returned `mantella_init_completed` response from the server does not require a Papyrus response, and can be ignored
- Added flag to `mantella_start_conversation` request to note whether mic input is enabled. This allows the server to initialise the STT class as soon as possible
- Removed logic from `sendRequestForVoiceTranscribe()` function to read NPC names. This is now handled on the server side
- Reduced wait time in `WaitForSpecificNpcToFinishSpeaking()` from 2 seconds to 0.01 seconds when waiting for `_isTalking` to be set. This is the value set in the equivalent Skyrim Papryus script and there haven't been any problems so far